### PR TITLE
Fix pointers to value types (like *string)

### DIFF
--- a/swagger/util.go
+++ b/swagger/util.go
@@ -16,6 +16,12 @@ type reflectType interface {
 }
 
 func makeName(t reflectType) string {
-	name := filepath.Base(t.PkgPath()) + t.Name()
+	var name string
+	pkgPath := t.PkgPath()
+	if pkgPath == "" {
+		name = t.Name()
+	} else {
+		name = filepath.Base(pkgPath) + t.Name()
+	}
 	return strings.Replace(name, "-", "_", -1)
 }


### PR DESCRIPTION
When using a struct with *string elements makename() was returning .string which was not an available model.

In the case that t.PkgPath() returns "" the name is used alone without the path. (for built in types)